### PR TITLE
adds env var pass through for specific vars

### DIFF
--- a/crates/blockless-drivers/witx/blockless_memory.witx
+++ b/crates/blockless-drivers/witx/blockless_memory.witx
@@ -25,5 +25,10 @@
         (result $error (expected $num_bytes (error $blockless_memory_error)))
     )
 
+    (@interface func (export "env_var_read")
+        (param $body_buf $incoming_body_ptr)
+        (param $body_buf_len u32)
+        (result $error (expected $num_bytes (error $blockless_memory_error)))
+    )
 )
 


### PR DESCRIPTION
extends the memory driver, by pulling in specified env vars to the memory space.

the env vars need to be explicitly listed in the `BLS_VARS_LIST` before they are read.

the env should be clear before the wasm is expected

`env -i` as an example.