### PR TITLE
Phase out `ExitCode` for more verbose `CLIExitCode`

### DIFF
--- a/blockless-cli/src/error.rs
+++ b/blockless-cli/src/error.rs
@@ -1,4 +1,4 @@
-use std::{fmt, process::ExitCode};
+use std::{fmt, process::{ExitCode, Termination}};
 
 #[derive(Debug)]
 pub enum CLIExitCode {
@@ -104,10 +104,11 @@ impl Into<i32> for CLIExitCode {
   }
 }
 
-impl Into<ExitCode> for CLIExitCode {
-  fn into(self) -> ExitCode {
-    ExitCode::from(Into::<u8>::into(self))
-  }
-}
-
 impl std::error::Error for CLIExitCode {}
+
+impl Termination for CLIExitCode {
+    #[inline]
+    fn report(self) -> ExitCode {
+        ExitCode::from(Into::<u8>::into(self))
+    }
+}

--- a/blockless-cli/src/main.rs
+++ b/blockless-cli/src/main.rs
@@ -134,11 +134,8 @@ fn v86_runtime(path: &str) -> Result<i32, CLIExitCode> {
         .open(path)
         .map_err(|e| CLIExitCode::UnknownError(format!("the v86 car file does not exist or is unreadable: {}", e)))?;
 
-    let cfg = load_v86conf_extract_from_car(file)
-        .map_err(|e| CLIExitCode::UnknownError(format!("failed to extract conf from car file: {}", e)))?;
-
-    let v86 = V86Lib::load(&cfg.dynamic_lib_path)
-        .map_err(|e| CLIExitCode::UnknownError(format!("failed to load v86 lib: {}", e)))?;
+    let cfg = load_v86conf_extract_from_car(file)?;
+    let v86 = V86Lib::load(&cfg.dynamic_lib_path)?;
 
     let raw_config_json = &cfg.raw_config
         .ok_or_else(|| CLIExitCode::UnknownError("the v86 config file does not exist or is unreadable.".to_string()))?;

--- a/blockless-cli/src/main.rs
+++ b/blockless-cli/src/main.rs
@@ -99,10 +99,6 @@ fn check_module_sum(cfg: &CliConfig) -> Result<(), CLIExitCode> {
     Ok(())
 }
 
-fn load_wasm_directly(wasmfile: &str) -> CliConfig {
-    CliConfig::new_with_wasm(wasmfile)
-}
-
 /// the cli support 3 type file, 
 /// 1. the car file format, all files archive into the car file.
 /// 2. the wasm or wasi file format, will run wasm directly.
@@ -119,7 +115,7 @@ fn load_cli_config(file_path: &str) -> Result<CliConfig, CLIExitCode> {
             Some(load_cli_config_extract_from_car(file))
         },
         Some(ext) if ext == "wasm" || ext == "wasi" || ext == "wat" => {
-            Some(Ok(load_wasm_directly(file_path)))
+            Some(Ok(CliConfig::new_with_wasm(file_path)))
         },
         _ => None,
     };

--- a/blockless-cli/src/main.rs
+++ b/blockless-cli/src/main.rs
@@ -199,7 +199,7 @@ fn wasm_runtime(mut cfg: CliConfig, cli_command_opts: CliCommandOpts) -> CLIExit
 }
 
 
-fn cover_env(cli_command_opts: &CliCommandOpts) {
+fn set_root_path_env_var(cli_command_opts: &CliCommandOpts) {
     cli_command_opts
         .fs_root_path()
         .map(|s| std::env::set_var(ENV_ROOT_PATH_NAME, s.as_str()));
@@ -207,7 +207,7 @@ fn cover_env(cli_command_opts: &CliCommandOpts) {
 
 fn main() -> CLIExitCode {
     let cli_command_opts = CliCommandOpts::parse();
-    cover_env(&cli_command_opts);
+    set_root_path_env_var(&cli_command_opts);
     let path = cli_command_opts.input_ref();
 
     match cli_command_opts.runtime_type() {
@@ -250,6 +250,13 @@ mod test {
     use crate::config::load_cli_config_from_car;
 
     use super::*;
+
+    #[test]
+    fn test_set_root_path_env_var() {
+        let cli_opts = CliCommandOpts::try_parse_from(["cli", "test", "--fs-root-path=./test"]).unwrap();;
+        set_root_path_env_var(&cli_opts);
+        assert_eq!(std::env::var(ENV_ROOT_PATH_NAME).unwrap(), *cli_opts.fs_root_path().unwrap());
+    }
 
     #[test]
     fn test_load_cli_wasm_config() {

--- a/blockless-cli/src/v86.rs
+++ b/blockless-cli/src/v86.rs
@@ -1,8 +1,8 @@
 use core::ffi;
 use std::path::Path;
-
 use dlopen::raw::Library;
-use anyhow::Result;
+
+use crate::error::CLIExitCode;
 
 pub(crate) struct V86Lib {
     _lib: Library,
@@ -12,11 +12,12 @@ pub(crate) struct V86Lib {
 type V86WasiRunFuncType = unsafe extern "C" fn(conf :*const ffi::c_char, len: ffi::c_int) -> ffi::c_int;
 
 impl V86Lib {
-
-    pub fn load<T: AsRef<Path>>(path: T) -> Result<Self> {
-        let lib = Library::open(path.as_ref())?;
+    pub fn load<T: AsRef<Path>>(path: T) -> Result<V86Lib, CLIExitCode> {
+        let lib = Library::open(path.as_ref())
+            .map_err(|_| CLIExitCode::ConfigureError)?;
         let v86_wasi_run_func = unsafe {
-            lib.symbol("run_v86_wasi")?
+            lib.symbol("run_v86_wasi")
+                .map_err(|_| CLIExitCode::UnknownError("failed to load v86 wasi".to_string()))?
         };
         Ok(Self {
             _lib: lib,
@@ -26,10 +27,9 @@ impl V86Lib {
 
     pub fn v86_wasi_run(&self, path: &str) -> i32 {
         let path_len = path.len();
-        let pasth_ptr = path.as_ptr();
+        let path_ptr = path.as_ptr();
         unsafe {
-            (self.v86_wasi_run_func)(pasth_ptr as _, path_len as _)
+            (self.v86_wasi_run_func)(path_ptr as _, path_len as _)
         }
     }
-
 }


### PR DESCRIPTION
## Context
- A micro PR to phase out `ExitCode` (and the unnecessary `.into()` conversions)