### PR TITLE
Empty stdin shouldn't pause execution - 2

### DIFF
--- a/bls-runtime/src/main.rs
+++ b/bls-runtime/src/main.rs
@@ -315,12 +315,14 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_input_non_blocking_read() {
-        // test with a reader (a cursor over a static string)
+    async fn test_empty_input_non_blocking_read() {
         let cursor = std::io::Cursor::new("");
         let result = non_blocking_read(cursor).await;
-        assert_eq!(result, Some("".to_string()));
+        assert_eq!(result, None);
+    }
 
+    #[tokio::test]
+    async fn test_input_non_blocking_read() {
         let cursor = std::io::Cursor::new("test input");
         let result = non_blocking_read(cursor).await;
         assert_eq!(result, Some("test input".to_string()));

--- a/bls-runtime/src/main.rs
+++ b/bls-runtime/src/main.rs
@@ -183,7 +183,7 @@ async fn non_blocking_read<R: Read + Send + 'static>(mut reader: R) -> Option<St
     // spawn thread to read from the reader asynchronously
     std::thread::spawn(move || {
         let mut buffer = String::new();
-        if reader.read_to_string(&mut buffer).is_ok() { // blocks
+        if reader.read_to_string(&mut buffer).is_ok() && !buffer.is_empty() { // blocks
             let _ = tx.send(buffer);
         }
     });

--- a/bls-runtime/src/main.rs
+++ b/bls-runtime/src/main.rs
@@ -307,4 +307,22 @@ mod test {
         assert_eq!(cfg.0.fs_root_path_ref(), Some("target"));
         assert_eq!(cfg.0.drivers_root_path_ref(), Some("target/drivers"));
     }
+
+    #[tokio::test]
+    async fn test_no_input_non_blocking_read() {
+        let result = non_blocking_read(std::io::stdin()).await;
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_input_non_blocking_read() {
+        // test with a reader (a cursor over a static string)
+        let cursor = std::io::Cursor::new("");
+        let result = non_blocking_read(cursor).await;
+        assert_eq!(result, Some("".to_string()));
+
+        let cursor = std::io::Cursor::new("test input");
+        let result = non_blocking_read(cursor).await;
+        assert_eq!(result, Some("test input".to_string()));
+    }
 }


### PR DESCRIPTION
## Context
Addresses: https://linear.app/blockless/issue/ENG-964/empty-stdin-shouldnt-pause-execution
- Builds upon https://github.com/blocklessnetwork/bls-runtime/pull/64

Re-introduce stdin support - but keep it optional.
With this fix, we should be able to read the stdin using a non-blocking approach (which does not pause runtime execution).
 