### PR TITLE
LLM module driver

### DIFF
--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -654,6 +654,7 @@ impl BlocklessRunner {
         }
         add_to_linker!(blockless_env::add_drivers_to_linker);
         add_to_linker!(blockless_env::add_http_to_linker);
+        add_to_linker!(blockless_env::add_llm_to_linker);
         add_to_linker!(blockless_env::add_ipfs_to_linker);
         add_to_linker!(blockless_env::add_s3_to_linker);
         add_to_linker!(blockless_env::add_memory_to_linker);

--- a/crates/blockless-drivers/Cargo.toml
+++ b/crates/blockless-drivers/Cargo.toml
@@ -15,42 +15,34 @@ runtime = []
 
 [dependencies]
 blockless-drivers-macro = {path = "macro"}
-wasmtime-wasi = {workspace = true}
-wiggle = {workspace = true}
-wasi-common = {workspace = true}
-anyhow = {workspace = true}
-cap-std = {workspace = true}
-log = {workspace = true}
-async-trait = {workspace = true}
-dlopen = {workspace = true}
-json = {workspace = true}
-reqwest = {version = "0.12.9", features = ["stream", "rustls-tls"], default-features = false}
+blockless-multiaddr = {path = "../blockless-multiaddr"}
+wasmtime-wasi = { workspace = true }
+wiggle = { workspace = true }
+wasi-common = { workspace = true }
+anyhow = { workspace = true }
+cap-std = { workspace = true }
+log = { workspace = true }
+async-trait = { workspace = true }
+dlopen = { workspace = true }
+json = { workspace = true }
+lazy_static = { workspace = true}
+reqwest = { version = "0.11", features = ["stream", "rustls-tls", "json"], default-features = false }
 serde_urlencoded = "0.7"
 bytes = { workspace = true }
 httparse = "1"
 url = { workspace = true }
-rust-s3 = {git = "https://github.com/Joinhack/rust-s3", features = ["tokio-rustls-tls"]}
-futures-core = {workspace = true}
-futures-util = {workspace = true}
+rust-s3 = { git = "https://github.com/Joinhack/rust-s3", features = ["tokio-rustls-tls"] }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 md5 = "0.7.0"
-
-[dependencies.rusqlite]
-version = "0.28"
-features = ["bundled"]
-
+rusqlite = { version = "0.28", features = ["bundled"] }
+serde_json = "1.0.138"
+serde = "1.0.217"
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
-tempdir = {workspace = true}
+tempdir = { workspace = true }
 tokio-test = "0.4.2"
-
-
-[dependencies.lazy_static]
-workspace = true
-
-[dependencies.tokio]
-workspace = true
-features = ["net", "process", "fs"]
-
-
-[dependencies.blockless-multiaddr]
-path = "../blockless-multiaddr"
+tracing-subscriber = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/blockless-drivers/src/error.rs
+++ b/crates/blockless-drivers/src/error.rs
@@ -203,3 +203,15 @@ impl std::fmt::Display for BlocklessSocketErrorKind {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum LlmErrorKind {
+    ModelNotSet,               // 1
+    ModelNotSupported,         // 2
+    ModelInitializationFailed, // 3
+    ModelCompletionFailed,     // 4
+    ModelOptionsNotSet,        // 5
+    ModelShutdownFailed,       // 6
+    Utf8Error,                 // 7
+    RuntimeError,              // 8
+}

--- a/crates/blockless-drivers/src/ipfs_driver/http_raw.rs
+++ b/crates/blockless-drivers/src/ipfs_driver/http_raw.rs
@@ -109,8 +109,10 @@ impl HttpRaw {
         buf.write_all(format!("Content-Length: {}", body_buf.len()).as_bytes())
             .unwrap();
         buf.write_all(EOL).unwrap();
-        buf.write_all(format!("Content-Type: multipart/form-data; boundary={}", boundary).as_bytes())
-            .unwrap();
+        buf.write_all(
+            format!("Content-Type: multipart/form-data; boundary={}", boundary).as_bytes(),
+        )
+        .unwrap();
         buf.write_all(EOL).unwrap();
         buf.write_all(EOL).unwrap();
         buf.extend_from_slice(&body_buf);

--- a/crates/blockless-drivers/src/lib.rs
+++ b/crates/blockless-drivers/src/lib.rs
@@ -31,11 +31,7 @@ type OpenFuture = Pin<Box<dyn Future<Output = Result<Box<dyn WasiFile>, ErrorKin
 pub trait Driver {
     fn name(&self) -> &str;
 
-    fn open(
-        &self,
-        uri: &str,
-        opts: &str,
-    ) -> OpenFuture;
+    fn open(&self, uri: &str, opts: &str) -> OpenFuture;
 }
 
 lazy_static! {

--- a/crates/blockless-drivers/src/lib.rs
+++ b/crates/blockless-drivers/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cgi_driver;
 pub mod error;
 pub mod http_driver;
 pub mod ipfs_driver;
+pub mod llm_driver;
 pub mod memory_driver;
 pub mod read_ext;
 pub mod s3_driver;

--- a/crates/blockless-drivers/src/llm_driver/handle.rs
+++ b/crates/blockless-drivers/src/llm_driver/handle.rs
@@ -1,0 +1,115 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Mutex, MutexGuard,
+    },
+};
+
+/// A singleton map that manages handles to instances of type T
+pub struct HandleMap<T> {
+    contexts: Mutex<HashMap<u32, T>>,
+    next_handle: AtomicU32,
+}
+
+impl<T> Default for HandleMap<T> {
+    fn default() -> Self {
+        Self {
+            contexts: Mutex::new(HashMap::new()),
+            next_handle: AtomicU32::new(1),
+        }
+    }
+}
+
+impl<T> HandleMap<T> {
+    /// Generate a new unique handle
+    pub fn generate_handle(&self) -> u32 {
+        self.next_handle.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Insert a new instance and get its handle
+    pub fn insert(&self, instance: T) -> u32 {
+        let handle = self.generate_handle();
+        let mut contexts = self
+            .contexts
+            .lock()
+            .expect("Failed to acquire contexts lock");
+        contexts.insert(handle, instance);
+        handle
+    }
+
+    /// Remove an instance by its handle
+    pub fn remove(&self, handle: u32) -> Option<T> {
+        let mut contexts = self
+            .contexts
+            .lock()
+            .expect("Failed to acquire contexts lock");
+        contexts.remove(&handle)
+    }
+
+    /// Access a specific instance by handle
+    pub fn get(&self, handle: u32) -> Option<InstanceGuard<T>> {
+        let guard = self
+            .contexts
+            .lock()
+            .expect("Failed to acquire contexts lock");
+        if guard.contains_key(&handle) {
+            Some(InstanceGuard { guard, handle })
+        } else {
+            None
+        }
+    }
+}
+
+/// A guard that provides safe access to a specific instance
+pub struct InstanceGuard<'a, T> {
+    guard: MutexGuard<'a, HashMap<u32, T>>,
+    handle: u32,
+}
+
+impl<'a, T> Deref for InstanceGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.get(&self.handle).unwrap()
+    }
+}
+
+impl<'a, T> DerefMut for InstanceGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.guard.get_mut(&self.handle).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::LazyLock;
+
+    static HANDLES: LazyLock<HandleMap<String>> = LazyLock::new(HandleMap::default);
+
+    #[test]
+    fn test_handle_map() {
+        // Insert instances
+        let h1 = HANDLES.insert("test1".to_string());
+        let h2 = HANDLES.insert("test2".to_string());
+
+        // Access instances
+        assert_eq!(&*HANDLES.get(h1).unwrap(), "test1");
+        assert_eq!(&*HANDLES.get(h2).unwrap(), "test2");
+
+        // Modify instance
+        if let Some(mut guard) = HANDLES.get(h1) {
+            *guard = "modified".to_string();
+        }
+
+        // Verify modification
+        assert_eq!(&*HANDLES.get(h1).unwrap(), "modified");
+
+        // Remove instance
+        let removed = HANDLES.remove(h1).unwrap();
+        assert_eq!(removed, "modified");
+        assert!(HANDLES.get(h1).is_none());
+    }
+}

--- a/crates/blockless-drivers/src/llm_driver/llamafile.rs
+++ b/crates/blockless-drivers/src/llm_driver/llamafile.rs
@@ -220,6 +220,7 @@ mod tests {
             .try_init();
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_llamafile_lifecycle() {
         init_test_logging();

--- a/crates/blockless-drivers/src/llm_driver/llamafile.rs
+++ b/crates/blockless-drivers/src/llm_driver/llamafile.rs
@@ -248,11 +248,11 @@ mod tests {
 
     #[test]
     fn test_model_parsing() {
-      assert!(SupportedModels::from_str("Llama-3.2-1B-Instruct").is_ok());
-      assert!(SupportedModels::from_str("Llama-3.2-1B-Instruct-Q6_K").is_ok());
+        assert!(SupportedModels::from_str("Llama-3.2-1B-Instruct").is_ok());
+        assert!(SupportedModels::from_str("Llama-3.2-1B-Instruct-Q6_K").is_ok());
 
-      assert!(SupportedModels::from_str("Llama-3.2-3B-Instruct").is_ok());
-      assert!(SupportedModels::from_str("Llama-3.2-3B-Instruct-Q6_K").is_ok());
-      assert!(SupportedModels::from_str("unsupported-model").is_err());
+        assert!(SupportedModels::from_str("Llama-3.2-3B-Instruct").is_ok());
+        assert!(SupportedModels::from_str("Llama-3.2-3B-Instruct-Q6_K").is_ok());
+        assert!(SupportedModels::from_str("unsupported-model").is_err());
     }
 }

--- a/crates/blockless-drivers/src/llm_driver/llamafile.rs
+++ b/crates/blockless-drivers/src/llm_driver/llamafile.rs
@@ -1,0 +1,208 @@
+use crate::llm_driver::{
+    models::SupportedModels,
+    provider::{LLMProvider, Message, ProviderConfig, ProviderError},
+};
+use reqwest;
+use std::{
+    io::Write,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+};
+use tokio::fs;
+use tracing::{debug, info};
+
+/// The base path for the models from home directory
+const BASE_MODEL_PATH: &str = ".blessnet/models";
+const LLAMAFILE_BASE_URL: &str = "https://huggingface.co/Mozilla";
+
+#[derive(Debug)]
+pub struct LlamafileProvider {
+    pub model: SupportedModels,
+    process: Option<Child>,
+    config: ProviderConfig,
+}
+
+impl Default for LlamafileProvider {
+    fn default() -> Self {
+        Self::new(SupportedModels::Llama323BInstruct(None))
+    }
+}
+
+impl Clone for LlamafileProvider {
+    fn clone(&self) -> Self {
+        Self {
+            model: self.model.clone(),
+            process: None,
+            config: self.config.clone(),
+        }
+    }
+}
+
+impl LlamafileProvider {
+    pub fn new(model: SupportedModels) -> Self {
+        Self {
+            model,
+            process: None,
+            config: ProviderConfig::default(),
+        }
+    }
+
+    fn model_file_url(&self) -> url::Url {
+        let model_name = self.model.model_repo();
+        let model_file = self.model.model_file();
+        let url = format!(
+            "{}/{}/resolve/main/{}?download=true",
+            LLAMAFILE_BASE_URL, model_name, model_file
+        );
+        url::Url::parse(&url).unwrap()
+    }
+
+    fn get_model_path(&self) -> PathBuf {
+        std::env::var_os("HOME")
+            .map(|home| {
+                PathBuf::from(home)
+                    .join(BASE_MODEL_PATH)
+                    .join(self.model.model_file())
+            })
+            .unwrap()
+    }
+
+    async fn ensure_model_exists(&self) -> Result<(), ProviderError> {
+        let model_path = self.get_model_path();
+        if !model_path.exists() {
+            info!(
+                "Model not found, downloading to `{}`...",
+                model_path.display()
+            );
+            self.download_model().await?;
+        }
+        Ok(())
+    }
+
+    async fn download_model(&self) -> Result<(), ProviderError> {
+        let model_path = self.get_model_path();
+        let model_dir = model_path.parent().unwrap();
+        fs::create_dir_all(model_dir)
+            .await
+            .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?;
+
+        let url = self.model_file_url();
+        let response = reqwest::get(url)
+            .await
+            .map_err(|e| ProviderError::CommunicationError(e.to_string()))?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| ProviderError::CommunicationError(e.to_string()))?;
+
+        let mut file = std::fs::File::create(&model_path)
+            .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?;
+        file.write_all(&bytes)
+            .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = file
+                .metadata()
+                .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?
+                .permissions();
+            perms.set_mode(0o755);
+            file.set_permissions(perms)
+                .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    fn start_server(&mut self) -> Result<(), ProviderError> {
+        let model_path = self.get_model_path();
+        let process = Command::new(&model_path)
+            .arg("--server")
+            .arg("--nobrowser")
+            .arg("--host")
+            .arg(&self.config.host)
+            .arg("--port")
+            .arg(self.config.port.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ProviderError::InitializationFailed(e.to_string()))?;
+
+        self.process = Some(process);
+        debug!(
+            "Started llamafile server on {}:{}",
+            self.config.host, self.config.port
+        );
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LLMProvider for LlamafileProvider {
+    async fn initialize(&mut self, config: &ProviderConfig) -> Result<(), ProviderError> {
+        info!(
+            "Initializing Llamafile provider for model: {}",
+            self.model.to_string()
+        );
+        self.config = config.clone();
+        self.ensure_model_exists().await?;
+        self.start_server()?;
+
+        // Wait for server to start
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        Ok(())
+    }
+
+    async fn chat(&self, messages: Vec<Message>) -> Result<Message, ProviderError> {
+        let client = reqwest::Client::new();
+        let url = format!(
+            "http://{}:{}/v1/chat/completions",
+            self.config.host, self.config.port
+        );
+
+        let payload = serde_json::json!({
+          "model": "LLaMA_CPP",
+          "messages": messages,
+        });
+
+        let response = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .timeout(self.config.timeout)
+            .send()
+            .await
+            .map_err(|e| ProviderError::CommunicationError(e.to_string()))?;
+
+        let response_data: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+
+        let content = response_data["choices"][0]["message"].clone();
+        serde_json::from_value(content).map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+    }
+
+    fn shutdown(&mut self) -> Result<(), ProviderError> {
+        if let Some(mut process) = self.process.take() {
+            process
+                .kill()
+                .map_err(|e| ProviderError::ShutdownError(e.to_string()))?;
+            process
+                .wait()
+                .map_err(|e| ProviderError::ShutdownError(e.to_string()))?;
+            debug!("Stopped llamafile server");
+        }
+        Ok(())
+    }
+}
+
+impl Drop for LlamafileProvider {
+    fn drop(&mut self) {
+        if let Err(e) = self.shutdown() {
+            debug!("Failed to shutdown llamafile server: {}", e);
+        }
+    }
+}
+

--- a/crates/blockless-drivers/src/llm_driver/mod.rs
+++ b/crates/blockless-drivers/src/llm_driver/mod.rs
@@ -1,0 +1,201 @@
+mod handle;
+mod llamafile;
+mod models;
+mod provider;
+
+use crate::LlmErrorKind;
+use handle::HandleMap;
+use llamafile::LlamafileProvider;
+use models::SupportedModels;
+use provider::{LLMProvider, Message, ProviderConfig};
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+// Global variables (single instance of the context map)
+static CONTEXTS: LazyLock<HandleMap<LlmContext<LlamafileProvider>>> =
+    LazyLock::new(HandleMap::default);
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LlmOptions {
+    pub system_message: String,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+}
+
+#[derive(Clone)]
+pub struct LlmContext<P: LLMProvider + Clone> {
+    model: String,
+    provider: P,
+    options: LlmOptions,
+    messages: Vec<Message>,
+}
+
+impl<P: LLMProvider + Clone> LlmContext<P> {
+    async fn new(model: String, mut provider: P) -> Result<Self, LlmErrorKind> {
+        provider
+            .initialize(&ProviderConfig::default())
+            .await
+            .map_err(|_| LlmErrorKind::ModelInitializationFailed)?;
+
+        Ok(Self {
+            model,
+            provider,
+            options: LlmOptions::default(),
+            messages: Vec::new(),
+        })
+    }
+
+    fn add_message(&mut self, role: &str, content: &str) {
+        self.messages.push(Message {
+            role: role.to_string(),
+            content: content.to_string(),
+        });
+    }
+}
+
+pub async fn llm_set_model(model: &str) -> Result<u32, LlmErrorKind> {
+    // Parse model string to SupportedModels
+    let supported_model: SupportedModels =
+        model.parse().map_err(|_| LlmErrorKind::ModelNotSupported)?;
+
+    // Create provider and context
+    let provider = LlamafileProvider::new(supported_model);
+    let context = LlmContext::new(model.to_string(), provider)
+        .await
+        .map_err(|_| LlmErrorKind::ModelInitializationFailed)?;
+
+    tracing::info!("Model set: {}", model);
+
+    Ok(CONTEXTS.insert(context))
+}
+
+pub async fn llm_get_model(handle: u32) -> Result<String, LlmErrorKind> {
+    let ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+    Ok(ctx.model.clone())
+}
+
+pub async fn llm_set_options(handle: u32, options: &[u8]) -> Result<(), LlmErrorKind> {
+    let mut ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+    let parsed_options: LlmOptions =
+        serde_json::from_slice(options).map_err(|_| LlmErrorKind::ModelOptionsNotSet)?;
+
+    if !parsed_options.system_message.is_empty() {
+        ctx.messages.clear();
+        ctx.add_message("system", &parsed_options.system_message);
+    }
+
+    ctx.options = parsed_options;
+    Ok(())
+}
+
+pub async fn llm_get_options(handle: u32) -> Result<LlmOptions, LlmErrorKind> {
+    let ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+    Ok(ctx.options.clone())
+}
+
+pub async fn llm_prompt(handle: u32, prompt: &str) -> Result<(), LlmErrorKind> {
+    let mut ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+    ctx.add_message("user", prompt);
+    Ok(())
+}
+
+pub async fn llm_read_response(handle: u32) -> Result<String, LlmErrorKind> {
+    // Get all necessary data from the context before the async operation
+    let (provider, messages) = {
+        let ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+        (ctx.provider.clone(), ctx.messages.clone())
+    };
+
+    // Perform the async chat operation
+    let response = provider
+        .chat(messages)
+        .await
+        .map_err(|_| LlmErrorKind::ModelCompletionFailed)?;
+
+    // Update the context with the response
+    let mut ctx = CONTEXTS.get(handle).ok_or(LlmErrorKind::ModelNotSet)?;
+    ctx.add_message("assistant", &response.content.clone());
+
+    Ok(response.content)
+}
+
+pub async fn llm_close(handle: u32) -> Result<(), LlmErrorKind> {
+    if let Some(mut ctx) = CONTEXTS.remove(handle) {
+        ctx.provider
+            .shutdown()
+            .map_err(|_| LlmErrorKind::ModelShutdownFailed)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::{info, Level};
+    use tracing_subscriber::FmtSubscriber;
+
+    #[tokio::test]
+    async fn test_llm_driver_e2e() {
+        let _ = FmtSubscriber::builder()
+            .with_max_level(Level::DEBUG)
+            .with_test_writer()
+            .try_init();
+
+        info!("Starting E2E test for LLM driver");
+
+        // 1. Set model and verify
+        info!("Setting up model...");
+        let handle = llm_set_model("Llama-3.2-1B-Instruct").await.unwrap();
+        let model = llm_get_model(handle).await.unwrap();
+        assert_eq!(model, "Llama-3.2-1B-Instruct");
+
+        // 2. Set options and verify
+        let system_message = r#"
+        You are a helpful assistant.
+        First time I ask, you name will be lucy.
+        Second time I ask, you name will be bob.
+        "#;
+        let initial_options = LlmOptions {
+            system_message: system_message.to_string(),
+            temperature: Some(0.7),
+            top_p: Some(0.9),
+        };
+        let options_bytes = serde_json::to_vec(&initial_options).unwrap();
+        llm_set_options(handle, &options_bytes).await.unwrap();
+
+        let retrieved_options = llm_get_options(handle).await.unwrap();
+        assert_eq!(retrieved_options, initial_options);
+
+        // First interaction
+        let prompt1 = "What is your name?";
+        llm_prompt(handle, prompt1).await.unwrap();
+        let response1 = llm_read_response(handle).await.unwrap();
+        info!("Q1: {}\nA1: {}", prompt1, response1);
+        assert!(!response1.is_empty());
+
+        // Second interaction
+        let prompt2 = "What is your name?";
+        llm_prompt(handle, prompt2).await.unwrap();
+        let response2 = llm_read_response(handle).await.unwrap();
+        info!("Q2: {}\nA2: {}", prompt2, response2);
+        assert!(!response2.is_empty());
+
+        // Update options
+        let updated_options = LlmOptions {
+            system_message: "You are now a mathematics tutor.".to_string(),
+            temperature: Some(0.5),
+            top_p: Some(0.95),
+        };
+        let updated_options_bytes = serde_json::to_vec(&updated_options).unwrap();
+        llm_set_options(handle, &updated_options_bytes)
+            .await
+            .unwrap();
+
+        let final_options = llm_get_options(handle).await.unwrap();
+        assert_eq!(final_options, updated_options);
+
+        // Clean up
+        info!("Cleaning up...");
+        llm_close(handle).await.unwrap();
+    }
+}

--- a/crates/blockless-drivers/src/llm_driver/mod.rs
+++ b/crates/blockless-drivers/src/llm_driver/mod.rs
@@ -134,6 +134,7 @@ mod tests {
     use tracing::{info, Level};
     use tracing_subscriber::FmtSubscriber;
 
+    #[ignore]
     #[tokio::test]
     async fn test_llm_driver_e2e() {
         let _ = FmtSubscriber::builder()

--- a/crates/blockless-drivers/src/llm_driver/models.rs
+++ b/crates/blockless-drivers/src/llm_driver/models.rs
@@ -1,0 +1,136 @@
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum SupportedModels {
+    Llama321BInstruct(Option<String>),
+    Llama323BInstruct(Option<String>),
+    Mistral7BInstructV03(Option<String>),
+    Mixtral8x7BInstructV01(Option<String>),
+    Gemma22BInstruct(Option<String>),
+    Gemma27BInstruct(Option<String>),
+    Gemma29BInstruct(Option<String>),
+}
+
+impl SupportedModels {
+    pub fn model_repo(&self) -> String {
+        match self {
+            SupportedModels::Llama321BInstruct(_) => "Llama-3.2-1B-Instruct-llamafile".to_string(),
+            SupportedModels::Llama323BInstruct(_) => "Llama-3.2-3B-Instruct-llamafile".to_string(),
+            SupportedModels::Mistral7BInstructV03(_) => {
+                "Mistral-7B-Instruct-v0.3-llamafile".to_string()
+            }
+            SupportedModels::Mixtral8x7BInstructV01(_) => {
+                "Mixtral-8x7B-Instruct-v0.1-llamafile".to_string()
+            }
+            SupportedModels::Gemma22BInstruct(_) => "gemma-2-2b-it-llamafile".to_string(),
+            SupportedModels::Gemma27BInstruct(_) => "gemma-2-27b-it-llamafile".to_string(),
+            SupportedModels::Gemma29BInstruct(_) => "gemma-2-9b-it-llamafile".to_string(),
+        }
+    }
+
+    pub fn model_file(&self) -> String {
+        match self {
+            SupportedModels::Llama321BInstruct(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("Llama-3.2-1B-Instruct.{}", suffix)
+            }
+            SupportedModels::Llama323BInstruct(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("Llama-3.2-3B-Instruct.{}", suffix)
+            }
+            SupportedModels::Mistral7BInstructV03(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("Mistral-7B-Instruct-v0.3.{}", suffix)
+            }
+            SupportedModels::Mixtral8x7BInstructV01(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("Mixtral-8x7B-Instruct-v0.1.{}", suffix)
+            }
+            SupportedModels::Gemma22BInstruct(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("gemma-2-2b-it.{}", suffix)
+            }
+            SupportedModels::Gemma27BInstruct(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("gemma-2-27b-it.{}", suffix)
+            }
+            SupportedModels::Gemma29BInstruct(quantization) => {
+                let suffix = quantization.clone().unwrap_or("Q6_K.llamafile".to_string());
+                format!("gemma-2-9b-it.{}", suffix)
+            }
+        }
+    }
+}
+
+impl FromStr for SupportedModels {
+  type Err = String;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+      match s {
+          // Llama 3.2 1B
+          "Llama-3.2-1B-Instruct" => Ok(SupportedModels::Llama321BInstruct(None)),
+          "Llama-3.2-1B-Instruct-Q6_K"
+          | "Llama-3.2-1B-Instruct_Q6_K"
+          | "Llama-3.2-1B-Instruct.Q6_K" => {
+              Ok(SupportedModels::Llama321BInstruct(Some("Q6_K".to_string())))
+          }
+          "Llama-3.2-1B-Instruct-q4f16_1" | "Llama-3.2-1B-Instruct.q4f16_1" => Ok(
+              SupportedModels::Llama321BInstruct(Some("q4f16_1".to_string())),
+          ),
+
+          // Llama 3.2 3B
+          "Llama-3.2-3B-Instruct" => Ok(SupportedModels::Llama323BInstruct(None)),
+          "Llama-3.2-3B-Instruct-Q6_K"
+          | "Llama-3.2-3B-Instruct_Q6_K"
+          | "Llama-3.2-3B-Instruct.Q6_K" => {
+              Ok(SupportedModels::Llama323BInstruct(Some("Q6_K".to_string())))
+          }
+          "Llama-3.2-3B-Instruct-q4f16_1" | "Llama-3.2-3B-Instruct.q4f16_1" => Ok(
+              SupportedModels::Llama323BInstruct(Some("q4f16_1".to_string())),
+          ),
+
+          // Mistral 7B
+          "Mistral-7B-Instruct-v0.3" => Ok(SupportedModels::Mistral7BInstructV03(None)),
+          "Mistral-7B-Instruct-v0.3-q4f16_1" | "Mistral-7B-Instruct-v0.3.q4f16_1" => Ok(
+              SupportedModels::Mistral7BInstructV03(Some("q4f16_1".to_string())),
+          ),
+
+          // Mixtral 8x7B
+          "Mixtral-8x7B-Instruct-v0.1" => Ok(SupportedModels::Mixtral8x7BInstructV01(None)),
+          "Mixtral-8x7B-Instruct-v0.1-q4f16_1" | "Mixtral-8x7B-Instruct-v0.1.q4f16_1" => Ok(
+              SupportedModels::Mixtral8x7BInstructV01(Some("q4f16_1".to_string())),
+          ),
+
+          // Gemma models
+          "gemma-2-2b-it" => Ok(SupportedModels::Gemma22BInstruct(None)),
+          "gemma-2-2b-it-q4f16_1" | "gemma-2-2b-it.q4f16_1" => Ok(
+              SupportedModels::Gemma22BInstruct(Some("q4f16_1".to_string())),
+          ),
+
+          "gemma-2-27b-it" => Ok(SupportedModels::Gemma27BInstruct(None)),
+          "gemma-2-27b-it-q4f16_1" | "gemma-2-27b-it.q4f16_1" => Ok(
+              SupportedModels::Gemma27BInstruct(Some("q4f16_1".to_string())),
+          ),
+
+          "gemma-2-9b-it" => Ok(SupportedModels::Gemma29BInstruct(None)),
+          "gemma-2-9b-it-q4f16_1" | "gemma-2-9b-it.q4f16_1" => Ok(
+              SupportedModels::Gemma29BInstruct(Some("q4f16_1".to_string())),
+          ),
+
+          _ => Err(format!("Unsupported model: {}", s)),
+      }
+  }
+}
+
+impl ToString for SupportedModels {
+  fn to_string(&self) -> String {
+    match self {
+      SupportedModels::Llama321BInstruct(_) => "Llama-3.2-1B-Instruct".to_string(),
+      SupportedModels::Llama323BInstruct(_) => "Llama-3.2-3B-Instruct".to_string(),
+      SupportedModels::Mistral7BInstructV03(_) => "Mistral-7B-Instruct-v0.3".to_string(),
+      SupportedModels::Mixtral8x7BInstructV01(_) => "Mixtral-8x7B-Instruct-v0.1".to_string(),
+      SupportedModels::Gemma22BInstruct(_) => "gemma-2-2b-it".to_string(),
+      SupportedModels::Gemma27BInstruct(_) => "gemma-2-27b-it".to_string(),
+      SupportedModels::Gemma29BInstruct(_) => "gemma-2-9b-it".to_string(),
+    }
+  }
+}

--- a/crates/blockless-drivers/src/llm_driver/models.rs
+++ b/crates/blockless-drivers/src/llm_driver/models.rs
@@ -63,74 +63,74 @@ impl SupportedModels {
 }
 
 impl FromStr for SupportedModels {
-  type Err = String;
-  fn from_str(s: &str) -> Result<Self, Self::Err> {
-      match s {
-          // Llama 3.2 1B
-          "Llama-3.2-1B-Instruct" => Ok(SupportedModels::Llama321BInstruct(None)),
-          "Llama-3.2-1B-Instruct-Q6_K"
-          | "Llama-3.2-1B-Instruct_Q6_K"
-          | "Llama-3.2-1B-Instruct.Q6_K" => {
-              Ok(SupportedModels::Llama321BInstruct(Some("Q6_K".to_string())))
-          }
-          "Llama-3.2-1B-Instruct-q4f16_1" | "Llama-3.2-1B-Instruct.q4f16_1" => Ok(
-              SupportedModels::Llama321BInstruct(Some("q4f16_1".to_string())),
-          ),
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            // Llama 3.2 1B
+            "Llama-3.2-1B-Instruct" => Ok(SupportedModels::Llama321BInstruct(None)),
+            "Llama-3.2-1B-Instruct-Q6_K"
+            | "Llama-3.2-1B-Instruct_Q6_K"
+            | "Llama-3.2-1B-Instruct.Q6_K" => {
+                Ok(SupportedModels::Llama321BInstruct(Some("Q6_K".to_string())))
+            }
+            "Llama-3.2-1B-Instruct-q4f16_1" | "Llama-3.2-1B-Instruct.q4f16_1" => Ok(
+                SupportedModels::Llama321BInstruct(Some("q4f16_1".to_string())),
+            ),
 
-          // Llama 3.2 3B
-          "Llama-3.2-3B-Instruct" => Ok(SupportedModels::Llama323BInstruct(None)),
-          "Llama-3.2-3B-Instruct-Q6_K"
-          | "Llama-3.2-3B-Instruct_Q6_K"
-          | "Llama-3.2-3B-Instruct.Q6_K" => {
-              Ok(SupportedModels::Llama323BInstruct(Some("Q6_K".to_string())))
-          }
-          "Llama-3.2-3B-Instruct-q4f16_1" | "Llama-3.2-3B-Instruct.q4f16_1" => Ok(
-              SupportedModels::Llama323BInstruct(Some("q4f16_1".to_string())),
-          ),
+            // Llama 3.2 3B
+            "Llama-3.2-3B-Instruct" => Ok(SupportedModels::Llama323BInstruct(None)),
+            "Llama-3.2-3B-Instruct-Q6_K"
+            | "Llama-3.2-3B-Instruct_Q6_K"
+            | "Llama-3.2-3B-Instruct.Q6_K" => {
+                Ok(SupportedModels::Llama323BInstruct(Some("Q6_K".to_string())))
+            }
+            "Llama-3.2-3B-Instruct-q4f16_1" | "Llama-3.2-3B-Instruct.q4f16_1" => Ok(
+                SupportedModels::Llama323BInstruct(Some("q4f16_1".to_string())),
+            ),
 
-          // Mistral 7B
-          "Mistral-7B-Instruct-v0.3" => Ok(SupportedModels::Mistral7BInstructV03(None)),
-          "Mistral-7B-Instruct-v0.3-q4f16_1" | "Mistral-7B-Instruct-v0.3.q4f16_1" => Ok(
-              SupportedModels::Mistral7BInstructV03(Some("q4f16_1".to_string())),
-          ),
+            // Mistral 7B
+            "Mistral-7B-Instruct-v0.3" => Ok(SupportedModels::Mistral7BInstructV03(None)),
+            "Mistral-7B-Instruct-v0.3-q4f16_1" | "Mistral-7B-Instruct-v0.3.q4f16_1" => Ok(
+                SupportedModels::Mistral7BInstructV03(Some("q4f16_1".to_string())),
+            ),
 
-          // Mixtral 8x7B
-          "Mixtral-8x7B-Instruct-v0.1" => Ok(SupportedModels::Mixtral8x7BInstructV01(None)),
-          "Mixtral-8x7B-Instruct-v0.1-q4f16_1" | "Mixtral-8x7B-Instruct-v0.1.q4f16_1" => Ok(
-              SupportedModels::Mixtral8x7BInstructV01(Some("q4f16_1".to_string())),
-          ),
+            // Mixtral 8x7B
+            "Mixtral-8x7B-Instruct-v0.1" => Ok(SupportedModels::Mixtral8x7BInstructV01(None)),
+            "Mixtral-8x7B-Instruct-v0.1-q4f16_1" | "Mixtral-8x7B-Instruct-v0.1.q4f16_1" => Ok(
+                SupportedModels::Mixtral8x7BInstructV01(Some("q4f16_1".to_string())),
+            ),
 
-          // Gemma models
-          "gemma-2-2b-it" => Ok(SupportedModels::Gemma22BInstruct(None)),
-          "gemma-2-2b-it-q4f16_1" | "gemma-2-2b-it.q4f16_1" => Ok(
-              SupportedModels::Gemma22BInstruct(Some("q4f16_1".to_string())),
-          ),
+            // Gemma models
+            "gemma-2-2b-it" => Ok(SupportedModels::Gemma22BInstruct(None)),
+            "gemma-2-2b-it-q4f16_1" | "gemma-2-2b-it.q4f16_1" => Ok(
+                SupportedModels::Gemma22BInstruct(Some("q4f16_1".to_string())),
+            ),
 
-          "gemma-2-27b-it" => Ok(SupportedModels::Gemma27BInstruct(None)),
-          "gemma-2-27b-it-q4f16_1" | "gemma-2-27b-it.q4f16_1" => Ok(
-              SupportedModels::Gemma27BInstruct(Some("q4f16_1".to_string())),
-          ),
+            "gemma-2-27b-it" => Ok(SupportedModels::Gemma27BInstruct(None)),
+            "gemma-2-27b-it-q4f16_1" | "gemma-2-27b-it.q4f16_1" => Ok(
+                SupportedModels::Gemma27BInstruct(Some("q4f16_1".to_string())),
+            ),
 
-          "gemma-2-9b-it" => Ok(SupportedModels::Gemma29BInstruct(None)),
-          "gemma-2-9b-it-q4f16_1" | "gemma-2-9b-it.q4f16_1" => Ok(
-              SupportedModels::Gemma29BInstruct(Some("q4f16_1".to_string())),
-          ),
+            "gemma-2-9b-it" => Ok(SupportedModels::Gemma29BInstruct(None)),
+            "gemma-2-9b-it-q4f16_1" | "gemma-2-9b-it.q4f16_1" => Ok(
+                SupportedModels::Gemma29BInstruct(Some("q4f16_1".to_string())),
+            ),
 
-          _ => Err(format!("Unsupported model: {}", s)),
-      }
-  }
+            _ => Err(format!("Unsupported model: {}", s)),
+        }
+    }
 }
 
 impl ToString for SupportedModels {
-  fn to_string(&self) -> String {
-    match self {
-      SupportedModels::Llama321BInstruct(_) => "Llama-3.2-1B-Instruct".to_string(),
-      SupportedModels::Llama323BInstruct(_) => "Llama-3.2-3B-Instruct".to_string(),
-      SupportedModels::Mistral7BInstructV03(_) => "Mistral-7B-Instruct-v0.3".to_string(),
-      SupportedModels::Mixtral8x7BInstructV01(_) => "Mixtral-8x7B-Instruct-v0.1".to_string(),
-      SupportedModels::Gemma22BInstruct(_) => "gemma-2-2b-it".to_string(),
-      SupportedModels::Gemma27BInstruct(_) => "gemma-2-27b-it".to_string(),
-      SupportedModels::Gemma29BInstruct(_) => "gemma-2-9b-it".to_string(),
+    fn to_string(&self) -> String {
+        match self {
+            SupportedModels::Llama321BInstruct(_) => "Llama-3.2-1B-Instruct".to_string(),
+            SupportedModels::Llama323BInstruct(_) => "Llama-3.2-3B-Instruct".to_string(),
+            SupportedModels::Mistral7BInstructV03(_) => "Mistral-7B-Instruct-v0.3".to_string(),
+            SupportedModels::Mixtral8x7BInstructV01(_) => "Mixtral-8x7B-Instruct-v0.1".to_string(),
+            SupportedModels::Gemma22BInstruct(_) => "gemma-2-2b-it".to_string(),
+            SupportedModels::Gemma27BInstruct(_) => "gemma-2-27b-it".to_string(),
+            SupportedModels::Gemma29BInstruct(_) => "gemma-2-9b-it".to_string(),
+        }
     }
-  }
 }

--- a/crates/blockless-drivers/src/llm_driver/provider.rs
+++ b/crates/blockless-drivers/src/llm_driver/provider.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug)]
+pub enum ProviderError {
+    InitializationFailed(String),
+    CommunicationError(String),
+    InvalidResponse(String),
+    ShutdownError(String),
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InitializationFailed(msg) => write!(f, "Initialization failed: {}", msg),
+            Self::CommunicationError(msg) => write!(f, "Communication error: {}", msg),
+            Self::InvalidResponse(msg) => write!(f, "Invalid response: {}", msg),
+            Self::ShutdownError(msg) => write!(f, "Shutdown error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    pub host: String,
+    pub port: u16,
+    pub timeout: std::time::Duration,
+}
+
+impl Default for ProviderConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            timeout: std::time::Duration::from_secs(30),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait LLMProvider: Send + Sync + std::fmt::Debug {
+    /// Initialize the provider with any necessary setup
+    async fn initialize(&mut self, config: &ProviderConfig) -> Result<(), ProviderError>;
+
+    /// Generate a chat completion based on the conversation history
+    async fn chat(&self, messages: Vec<Message>) -> Result<Message, ProviderError>;
+
+    /// Perform any necessary cleanup when shutting down
+    fn shutdown(&mut self) -> Result<(), ProviderError>;
+}

--- a/crates/blockless-drivers/src/wasi/llm.rs
+++ b/crates/blockless-drivers/src/wasi/llm.rs
@@ -1,0 +1,166 @@
+#![allow(non_upper_case_globals)]
+use crate::{llm_driver, LlmErrorKind};
+use log::error;
+use wasi_common::WasiCtx;
+use wiggle::{GuestMemory, GuestPtr};
+
+wiggle::from_witx!({
+    witx: ["$BLOCKLESS_DRIVERS_ROOT/witx/blockless_llm.witx"],
+    errors: { llm_error => LlmErrorKind },
+    async: *,
+    wasmtime: false,
+});
+
+impl types::UserErrorConversion for WasiCtx {
+    fn llm_error_from_llm_error_kind(
+        &mut self,
+        e: self::LlmErrorKind,
+    ) -> wiggle::anyhow::Result<types::LlmError> {
+        Ok(e.into())
+    }
+}
+
+impl From<LlmErrorKind> for types::LlmError {
+    fn from(e: LlmErrorKind) -> types::LlmError {
+        use types::LlmError;
+        match e {
+            LlmErrorKind::ModelNotSet => LlmError::ModelNotSet,
+            LlmErrorKind::ModelNotSupported => LlmError::ModelNotSupported,
+            LlmErrorKind::ModelInitializationFailed => LlmError::ModelInitializationFailed,
+            LlmErrorKind::ModelCompletionFailed => LlmError::ModelCompletionFailed,
+            LlmErrorKind::ModelOptionsNotSet => LlmError::ModelOptionsNotSet,
+            LlmErrorKind::ModelShutdownFailed => LlmError::ModelShutdownFailed,
+            LlmErrorKind::Utf8Error => LlmError::Utf8Error,
+            LlmErrorKind::RuntimeError => LlmError::RuntimeError,
+        }
+    }
+}
+
+impl wiggle::GuestErrorType for types::LlmError {
+    fn success() -> Self {
+        Self::Success
+    }
+}
+
+#[wiggle::async_trait]
+impl blockless_llm::BlocklessLlm for WasiCtx {
+    /// Sets the LLM model
+    /// - Mutates the handle to point to the new model/instance
+    async fn llm_set_model_request(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: GuestPtr<types::LlmHandle>,
+        model: GuestPtr<str>,
+    ) -> Result<(), LlmErrorKind> {
+        let model: &str = memory
+            .as_str(model)
+            .map_err(|e| {
+                error!("guest model error: {}", e);
+                LlmErrorKind::Utf8Error
+            })?
+            .unwrap();
+        let fd = llm_driver::llm_set_model(model).await?;
+        memory
+            .write(handle, fd.into())
+            .map_err(|_| LlmErrorKind::RuntimeError)?;
+        return Ok(());
+    }
+
+    /// Gets the current model name
+    /// - Writes the model name to the buffer
+    /// - Returns the number of bytes written to the buffer
+    async fn llm_get_model_response(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+        buf: GuestPtr<u8>,
+        buf_len: u8,
+    ) -> Result<u8, LlmErrorKind> {
+        let model = llm_driver::llm_get_model(handle.into()).await?;
+        let bytes = model.as_bytes();
+        let copyn = buf_len.min(bytes.len() as u8);
+        memory
+            .copy_from_slice(&bytes[..copyn as usize], buf.as_array(copyn as u32))
+            .map_err(|_| LlmErrorKind::RuntimeError)?;
+        Ok(copyn as u8)
+    }
+
+    /// Sets the LLM model
+    /// - Mutates the handle to point to the new model/instance
+    async fn llm_set_model_options_request(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+        options: GuestPtr<str>,
+    ) -> Result<(), LlmErrorKind> {
+        let options: &str = memory
+            .as_str(options)
+            .map_err(|e| {
+                error!("guest options error: {}", e);
+                LlmErrorKind::Utf8Error
+            })?
+            .unwrap();
+        llm_driver::llm_set_options(handle.into(), options.as_bytes()).await?;
+        return Ok(());
+    }
+
+    /// Gets the model options
+    /// - Writes the model options to the buffer
+    /// - Returns the number of bytes written to the buffer
+    async fn llm_get_model_options(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+        buf: GuestPtr<u8>,
+        buf_len: u16,
+    ) -> Result<u16, LlmErrorKind> {
+        let options = llm_driver::llm_get_options(handle.into()).await?;
+        let bytes = serde_json::to_vec(&options).map_err(|_| LlmErrorKind::RuntimeError)?;
+        let copyn = buf_len.min(bytes.len() as u16);
+        memory
+            .copy_from_slice(&bytes[..copyn as usize], buf.as_array(copyn as u32))
+            .map_err(|_| LlmErrorKind::RuntimeError)?;
+        Ok(copyn as u16)
+    }
+
+    async fn llm_prompt_request(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+        prompt: GuestPtr<str>,
+    ) -> Result<(), LlmErrorKind> {
+        let prompt: &str = memory
+            .as_str(prompt)
+            .map_err(|e| {
+                error!("guest prompt error: {}", e);
+                LlmErrorKind::Utf8Error
+            })?
+            .unwrap();
+        llm_driver::llm_prompt(handle.into(), prompt).await?;
+        Ok(())
+    }
+
+    async fn llm_read_prompt_response(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+        buf: GuestPtr<u8>,
+        buf_len: u16,
+    ) -> Result<u16, LlmErrorKind> {
+        let response = llm_driver::llm_read_response(handle.into()).await?;
+        let bytes = response.as_bytes();
+        let copyn = buf_len.min(bytes.len() as u16);
+        memory
+            .copy_from_slice(&bytes[..copyn as usize], buf.as_array(copyn as u32))
+            .map_err(|_| LlmErrorKind::RuntimeError)?;
+        Ok(copyn as u16)
+    }
+
+    async fn llm_close(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        handle: types::LlmHandle,
+    ) -> Result<(), LlmErrorKind> {
+        llm_driver::llm_close(handle.into()).await
+    }
+}

--- a/crates/blockless-drivers/src/wasi/mod.rs
+++ b/crates/blockless-drivers/src/wasi/mod.rs
@@ -3,6 +3,7 @@ pub mod cgi;
 pub mod guest_ptr;
 pub mod http;
 pub mod ipfs;
+pub mod llm;
 pub mod memory;
 pub mod s3;
 pub mod socket;

--- a/crates/blockless-drivers/src/wasi/socket.rs
+++ b/crates/blockless-drivers/src/wasi/socket.rs
@@ -85,7 +85,10 @@ impl blockless_socket::BlocklessSocket for WasiCtx {
             .map_err(|_| BlocklessSocketErrorKind::ParameterError)?
             .unwrap();
         let mode = FileAccessMode::READ | FileAccessMode::WRITE;
-        match tcp_bind(&addr).await.map(|f| Arc::new(FileEntry::new(f, mode))) {
+        match tcp_bind(&addr)
+            .await
+            .map(|f| Arc::new(FileEntry::new(f, mode)))
+        {
             Ok(f) => {
                 let fd_num = self.table().push(f).unwrap();
                 let fd = types::SocketHandle::from(fd_num);
@@ -105,7 +108,10 @@ impl blockless_socket::BlocklessSocket for WasiCtx {
             .map_err(|_| BlocklessSocketErrorKind::ParameterError)?
             .unwrap();
         let mode = FileAccessMode::READ | FileAccessMode::WRITE;
-        match tcp_connect(&addr).await.map(|f| Arc::new(FileEntry::new(f, mode))) {
+        match tcp_connect(&addr)
+            .await
+            .map(|f| Arc::new(FileEntry::new(f, mode)))
+        {
             Ok(f) => {
                 let fd_num = self.table().push(f).unwrap();
                 let fd = types::SocketHandle::from(fd_num);

--- a/crates/blockless-drivers/witx/blockless_http.witx
+++ b/crates/blockless-drivers/witx/blockless_http.witx
@@ -34,6 +34,7 @@
     $headers_validation_error
   )
 )
+
 ;;; Handles for the HTTP extensions
 (typename $http_handle (handle))
 

--- a/crates/blockless-drivers/witx/blockless_llm.witx
+++ b/crates/blockless-drivers/witx/blockless_llm.witx
@@ -1,0 +1,84 @@
+(typename $llm_error
+  (enum (@witx tag u16)
+    ;;; Success
+    $success
+    ;;; Model not set
+    $model_not_set
+    ;;; Model not supported
+    $model_not_supported
+    ;;; Model initialization failed
+    $model_initialization_failed
+    ;;; Model completion failed
+    $model_completion_failed
+    ;;; Options not set
+    $model_options_not_set
+    ;;; Model shutdown failed
+    $model_shutdown_failed
+    ;;; UTF-8 error
+    $utf8_error
+    ;;; Runtime error
+    $runtime_error
+  )
+)
+
+;;; Handle for LLM contexts
+(typename $llm_handle u32)
+
+;;; Number of bytes written with max u8
+(typename $written_bytes_u8 u8)
+
+;;; Number of bytes written with max u16
+(typename $written_bytes_u16 u16)
+
+(module $blockless_llm
+    ;;; Set the LLM model
+    (@interface func (export "llm_set_model_request")
+        (param $handle (@witx pointer $llm_handle))
+        (param $model string)
+        (result $error (expected (error $llm_error)))
+    )
+
+    ;;; Get the current model name
+    (@interface func (export "llm_get_model_response")
+        (param $handle $llm_handle)
+        (param $buf (@witx pointer u8))
+        (param $buf_len u8)
+        (result $error (expected $written_bytes_u8 (error $llm_error)))
+    )
+
+    ;;; Set the LLM model options
+    (@interface func (export "llm_set_model_options_request")
+        (param $handle $llm_handle)
+        (param $options string)
+        (result $error (expected (error $llm_error)))
+    )
+
+    ;;; Get the model options
+    (@interface func (export "llm_get_model_options")
+        (param $handle $llm_handle)
+        (param $buf (@witx pointer u8))
+        (param $buf_len u16)
+        (result $error (expected $written_bytes_u16 (error $llm_error)))
+    )
+
+    ;;; Prompt the LLM
+    (@interface func (export "llm_prompt_request")
+        (param $handle $llm_handle)
+        (param $prompt string)
+        (result $error (expected (error $llm_error)))
+    )
+
+    ;;; Read the prompt response
+    (@interface func (export "llm_read_prompt_response")
+        (param $handle $llm_handle)
+        (param $buf (@witx pointer u8))
+        (param $buf_len u16)
+        (result $error (expected $written_bytes_u16 (error $llm_error)))
+    )
+
+    ;;; Close a request handle
+    (@interface func (export "llm_close")
+        (param $handle $llm_handle)
+        (result $error (expected (error $llm_error)))
+    )
+)

--- a/crates/blockless-env/src/lib.rs
+++ b/crates/blockless-env/src/lib.rs
@@ -42,3 +42,9 @@ linker_integration!({
     target: blockless_drivers::wasi::socket,
     link_method: "add_socket_to_linker",
 });
+
+linker_integration!({
+    witx: ["$BLOCKLESS_DRIVERS_ROOT/witx/blockless_llm.witx"],
+    target: blockless_drivers::wasi::llm,
+    link_method: "add_llm_to_linker",
+});

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.84.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-wasip1"]
+profile = "default"


### PR DESCRIPTION
# Description

This PR introduces the LLM module for host runtime as a driver.
[Llamafile](https://github.com/Mozilla-Ocho/llamafile) is used as the LLM provider to download models and provide inference on demand for guest wasm apps.

## Other changes

- Added unit test for llamafile to test e2e lifecycle
- `Cargo.toml` updates
- `cargo fmt --all`
- Added a generic `HandleMap` as a singleton for handling instances of LLM models loaded in guest wasm apps
- Added `rust-toolchain.toml` to repo

## Dependent PRs
- https://github.com/blocklessnetwork/sdk-rust/pull/18
- https://github.com/blocklessnetwork/sdk-assemblyscript/pull/23
- https://github.com/blessnetwork/javy-bless-plugins/pull/4
- https://github.com/blessnetwork/sdk-ts/pull/10
