### PR TITLE
CI for cargo fmt check

### DIFF
--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
+      - name: Run fmt check
+        run: cargo fmt --all -- --check
       - name: Run clippy
         run: |
           rustup override set 1.85

--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -9,8 +9,8 @@
 //! Some convenience constructors are included for common backing types like `Vec<u8>` and `String`,
 //! but the virtual pipes can be instantiated with any `Read` or `Write` type.
 //!
-use crate::file::{FdFlags, FileType, WasiFile};
 use crate::Error;
+use crate::file::{FdFlags, FileType, WasiFile};
 use std::any::Any;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, RwLock};

--- a/crates/wasi-common/src/sched.rs
+++ b/crates/wasi-common/src/sched.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use crate::clocks::WasiMonotonicClock;
 use crate::file::WasiFile;
-use crate::Error;
 use cap_std::time::Instant;
 pub mod subscription;
 pub use cap_std::time::Duration;

--- a/crates/wasi-common/src/sched/subscription.rs
+++ b/crates/wasi-common/src/sched/subscription.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use crate::clocks::WasiMonotonicClock;
 use crate::file::WasiFile;
-use crate::Error;
 use bitflags::bitflags;
 use cap_std::time::{Duration, Instant};
 

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -1,7 +1,7 @@
 use crate::file::TableFileExt;
 use crate::sched::{
-    subscription::{RwEventFlags, SubscriptionResult},
     Poll, Userdata,
+    subscription::{RwEventFlags, SubscriptionResult},
 };
 use crate::snapshots::preview_1::types as snapshot1_types;
 use crate::snapshots::preview_1::wasi_snapshot_preview1::WasiSnapshotPreview1 as Snapshot1;

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -1,14 +1,14 @@
 use crate::{
+    I32Exit, SystemTimeSpec, WasiCtx,
     dir::{DirEntry, OpenResult, ReaddirCursor, ReaddirEntity, TableDirExt},
     file::{
         Advice, FdFlags, FdStat, FileAccessMode, FileEntry, FileType, Filestat, OFlags, RiFlags,
         RoFlags, SdFlags, SiFlags, TableFileExt, WasiFile,
     },
     sched::{
-        subscription::{RwEventFlags, SubscriptionResult},
         Poll, Userdata,
+        subscription::{RwEventFlags, SubscriptionResult},
     },
-    I32Exit, SystemTimeSpec, WasiCtx,
 };
 use cap_std::time::{Duration, SystemClock};
 use std::io::{IoSlice, IoSliceMut};
@@ -228,7 +228,9 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
                 .set_fdflags(FdFlags::from(flags))
                 .await
         } else {
-            log::warn!("`fd_fdstat_set_flags` does not work with wasi-threads enabled; see https://github.com/bytecodealliance/wasmtime/issues/5643");
+            log::warn!(
+                "`fd_fdstat_set_flags` does not work with wasi-threads enabled; see https://github.com/bytecodealliance/wasmtime/issues/5643"
+            );
             Err(Error::not_supported())
         }
     }

--- a/crates/wasi-common/src/sync/clocks.rs
+++ b/crates/wasi-common/src/sync/clocks.rs
@@ -1,6 +1,6 @@
 use crate::clocks::{WasiClocks, WasiMonotonicClock, WasiSystemClock};
 use cap_std::time::{Duration, Instant, SystemTime};
-use cap_std::{ambient_authority, AmbientAuthority};
+use cap_std::{AmbientAuthority, ambient_authority};
 use cap_time_ext::{MonotonicClockExt, SystemClockExt};
 
 pub struct SystemClock(cap_std::time::SystemClock);

--- a/crates/wasi-common/src/sync/dir.rs
+++ b/crates/wasi-common/src/sync/dir.rs
@@ -1,8 +1,8 @@
-use crate::sync::file::{filetype_from, File};
+use crate::sync::file::{File, filetype_from};
 use crate::{
+    Error, ErrorExt,
     dir::{ReaddirCursor, ReaddirEntity, WasiDir},
     file::{FdFlags, FileType, Filestat, OFlags},
-    Error, ErrorExt,
 };
 use cap_fs_ext::{DirEntryExt, DirExt, MetadataExt, OpenOptionsMaybeDirExt, SystemTimeSpec};
 use cap_std::fs;
@@ -432,7 +432,9 @@ mod test {
         match f.as_mut().poll(&mut cx) {
             Poll::Ready(val) => return val,
             Poll::Pending => {
-                panic!("Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store")
+                panic!(
+                    "Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store"
+                )
             }
         }
 

--- a/crates/wasi-common/src/sync/file.rs
+++ b/crates/wasi-common/src/sync/file.rs
@@ -1,6 +1,6 @@
 use crate::{
-    file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error, ErrorExt,
+    file::{Advice, FdFlags, FileType, Filestat, WasiFile},
 };
 use cap_fs_ext::MetadataExt;
 use fs_set_times::{SetTimes, SystemTimeSpec};

--- a/crates/wasi-common/src/sync/mod.rs
+++ b/crates/wasi-common/src/sync/mod.rs
@@ -28,7 +28,7 @@ pub use clocks::clocks_ctx;
 pub use sched::sched_ctx;
 
 use self::net::Socket;
-use crate::{file::FileAccessMode, table::Table, Error, WasiCtx, WasiFile};
+use crate::{Error, WasiCtx, WasiFile, file::FileAccessMode, table::Table};
 use cap_rand::{Rng, RngCore, SeedableRng};
 use std::mem;
 use std::path::Path;

--- a/crates/wasi-common/src/sync/net.rs
+++ b/crates/wasi-common/src/sync/net.rs
@@ -1,6 +1,6 @@
 use crate::{
-    file::{FdFlags, FileType, RiFlags, RoFlags, SdFlags, SiFlags, WasiFile},
     Error, ErrorExt,
+    file::{FdFlags, FileType, RiFlags, RoFlags, SdFlags, SiFlags, WasiFile},
 };
 #[cfg(windows)]
 use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
@@ -225,19 +225,11 @@ macro_rules! wasi_stream_write_impl {
             }
             async fn readable(&self) -> Result<(), Error> {
                 let (readable, _writeable) = is_read_write(&self.0)?;
-                if readable {
-                    Ok(())
-                } else {
-                    Err(Error::io())
-                }
+                if readable { Ok(()) } else { Err(Error::io()) }
             }
             async fn writable(&self) -> Result<(), Error> {
                 let (_readable, writeable) = is_read_write(&self.0)?;
-                if writeable {
-                    Ok(())
-                } else {
-                    Err(Error::io())
-                }
+                if writeable { Ok(()) } else { Err(Error::io()) }
             }
 
             async fn sock_recv<'a>(

--- a/crates/wasi-common/src/sync/sched.rs
+++ b/crates/wasi-common/src/sync/sched.rs
@@ -9,8 +9,8 @@ pub mod windows;
 pub use windows::poll_oneoff;
 
 use crate::{
-    sched::{Poll, WasiSched},
     Error,
+    sched::{Poll, WasiSched},
 };
 use std::thread;
 use std::time::Duration;

--- a/crates/wasi-common/src/sync/sched/unix.rs
+++ b/crates/wasi-common/src/sync/sched/unix.rs
@@ -1,5 +1,5 @@
 use crate::sched::subscription::{RwEventFlags, Subscription};
-use crate::{sched::Poll, Error, ErrorExt};
+use crate::{Error, ErrorExt, sched::Poll};
 use cap_std::time::Duration;
 use rustix::event::{PollFd, PollFlags};
 

--- a/crates/wasi-common/src/sync/sched/windows.rs
+++ b/crates/wasi-common/src/sync/sched/windows.rs
@@ -9,7 +9,7 @@
 // taken the time to improve it. See bug #2880.
 
 use crate::sched::subscription::{RwEventFlags, Subscription};
-use crate::{file::WasiFile, sched::Poll, Error, ErrorExt};
+use crate::{Error, ErrorExt, file::WasiFile, sched::Poll};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
 use std::sync::{LazyLock, Mutex};
 use std::thread;
@@ -166,7 +166,7 @@ impl StdinPoll {
             Err(TryRecvError::Disconnected) => {
                 return Err(Error::trap(anyhow::Error::msg(
                     "StdinPoll notify_rx channel closed",
-                )))
+                )));
             }
         }
 

--- a/crates/wasi-common/src/sync/stdio.rs
+++ b/crates/wasi-common/src/sync/stdio.rs
@@ -5,8 +5,8 @@ use std::io::{self, IsTerminal, Read, Write};
 use system_interface::io::ReadReady;
 
 use crate::{
-    file::{FdFlags, FileType, WasiFile},
     Error, ErrorExt,
+    file::{FdFlags, FileType, WasiFile},
 };
 #[cfg(windows)]
 use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};

--- a/crates/wasi-common/src/tokio/dir.rs
+++ b/crates/wasi-common/src/tokio/dir.rs
@@ -1,8 +1,8 @@
 use crate::tokio::{block_on_dummy_executor, file::File};
 use crate::{
+    Error, ErrorExt,
     dir::{ReaddirCursor, ReaddirEntity, WasiDir},
     file::{FdFlags, Filestat, OFlags},
-    Error, ErrorExt,
 };
 use std::any::Any;
 use std::path::PathBuf;

--- a/crates/wasi-common/src/tokio/file.rs
+++ b/crates/wasi-common/src/tokio/file.rs
@@ -1,7 +1,7 @@
 use crate::tokio::block_on_dummy_executor;
 use crate::{
-    file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error,
+    file::{Advice, FdFlags, FileType, Filestat, WasiFile},
 };
 #[cfg(windows)]
 use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
@@ -181,7 +181,7 @@ macro_rules! wasi_file_impl {
                 // async method to ensure this is the only Future which can access the RawFd during the
                 // lifetime of the AsyncFd.
                 use std::os::unix::io::AsRawFd;
-                use tokio::io::{unix::AsyncFd, Interest};
+                use tokio::io::{Interest, unix::AsyncFd};
                 let rawfd = self.0.borrow().as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::READABLE) {
                     Ok(asyncfd) => {
@@ -205,7 +205,7 @@ macro_rules! wasi_file_impl {
                 // async method to ensure this is the only Future which can access the RawFd during the
                 // lifetime of the AsyncFd.
                 use std::os::unix::io::AsRawFd;
-                use tokio::io::{unix::AsyncFd, Interest};
+                use tokio::io::{Interest, unix::AsyncFd};
                 let rawfd = self.0.borrow().as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::WRITABLE) {
                     Ok(asyncfd) => {

--- a/crates/wasi-common/src/tokio/mod.rs
+++ b/crates/wasi-common/src/tokio/mod.rs
@@ -7,7 +7,7 @@ pub mod stdio;
 use self::sched::sched_ctx;
 use crate::sync::net::Socket;
 pub use crate::sync::{clocks_ctx, random_ctx};
-use crate::{file::FileAccessMode, Error, Table, WasiCtx, WasiFile};
+use crate::{Error, Table, WasiCtx, WasiFile, file::FileAccessMode};
 pub use dir::Dir;
 pub use file::File;
 pub use net::*;

--- a/crates/wasi-common/src/tokio/sched.rs
+++ b/crates/wasi-common/src/tokio/sched.rs
@@ -9,8 +9,8 @@ mod windows;
 pub use windows::poll_oneoff;
 
 use crate::{
-    sched::{Duration, Poll, WasiSched},
     Error,
+    sched::{Duration, Poll, WasiSched},
 };
 
 pub fn sched_ctx() -> Box<dyn crate::WasiSched> {

--- a/crates/wasi-common/src/tokio/sched/unix.rs
+++ b/crates/wasi-common/src/tokio/sched/unix.rs
@@ -1,9 +1,9 @@
 use crate::{
-    sched::{
-        subscription::{RwEventFlags, Subscription},
-        Poll,
-    },
     Error,
+    sched::{
+        Poll,
+        subscription::{RwEventFlags, Subscription},
+    },
 };
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/wasi-common/src/tokio/sched/windows.rs
+++ b/crates/wasi-common/src/tokio/sched/windows.rs
@@ -1,6 +1,6 @@
 use crate::sync::sched::windows::poll_oneoff_;
 use crate::tokio::block_on_dummy_executor;
-use crate::{file::WasiFile, sched::Poll, Error};
+use crate::{Error, file::WasiFile, sched::Poll};
 
 pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     // Tokio doesn't provide us the AsyncFd primitive on Windows, so instead

--- a/crates/wasi-common/src/tokio/stdio.rs
+++ b/crates/wasi-common/src/tokio/stdio.rs
@@ -1,1 +1,1 @@
-pub use super::file::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
+pub use super::file::{Stderr, Stdin, Stdout, stderr, stdin, stdout};


### PR DESCRIPTION
## Description

This pull request primarily focuses on code cleanup and minor refactoring across multiple files in the `wasi-common` crate. The changes include reordering imports to follow a consistent style, improving readability by reformatting multi-line strings, and simplifying conditional logic. Additionally, it introduces a new job to check Rust formatting in the GitHub Actions workflow.

### Workflow Improvements:
* [`.github/workflows/rust-fmt.yml`](diffhunk://#diff-8c3161f8cbf684f0a4c2b7f8ac5dc4e4b5c8ffd20d4060537fa73d357340df7aR27-R28): Added a new step to run `cargo fmt --all -- --check` as part of the GitHub Actions workflow to enforce code formatting standards.

### Code Cleanup and Refactoring:
* **Import Reordering:**
  - Reordered imports across multiple files (e.g., `pipe.rs`, `sched.rs`, `sync/dir.rs`, `sync/file.rs`, `tokio/file.rs`) to follow a consistent and logical structure. [[1]](diffhunk://#diff-bd7a6f963d46ffbf563ae797c3ad3f25d6d2215e8afb2c2ebfa4aad528d71fb6L12-R13) [[2]](diffhunk://#diff-bfa4a205d23339ae117ecca07d15885b353a635b4e22f5ad1a31d3284af3cba4R1-L3) [[3]](diffhunk://#diff-5207699d6956f4c77e73943179752e8f6070f4f8549c15a96f965e4632b97a39L1-L5) [[4]](diffhunk://#diff-50648ef0d22ac648c0029f39f33f92d31397877253c7eafd215d9f61152aafedL3-R4) [[5]](diffhunk://#diff-88cba719a25e29eb8f2adefc4a063eb099e3a7242178987b8ab7810da3b518b6L8-R9)

* **String Reformatting:**
  - Reformatted long multi-line strings for better readability in `preview_1.rs` and `sync/dir.rs`. [[1]](diffhunk://#diff-40a165c1f24fb0428d93215436730254f0379f22e816a70e0e29a44ba99c8be4L231-R233) [[2]](diffhunk://#diff-5207699d6956f4c77e73943179752e8f6070f4f8549c15a96f965e4632b97a39L435-R437)

* **Simplified Conditional Logic:**
  - Simplified conditional expressions in `sync/net.rs` to reduce redundancy.

### Minor Fixes:
* **Miscellaneous Adjustments:**
  - Fixed minor inconsistencies in import ordering and formatting in various files, including `sync/sched.rs`, `tokio/sched/unix.rs`, and `sync/sched/windows.rs`. [[1]](diffhunk://#diff-11bd411c3baf8d25e185f18a1e05b3ecb616463e53292ecf231a66174ad4fb12L2-R2) [[2]](diffhunk://#diff-64f479f404b3f6c2166d6cbeff1ae61843f47563bd58fa52a8379459b2bd419cR2-L6) [[3]](diffhunk://#diff-0ad3ac790409553f7a69302050562b59c5154b6418bdee8b6f9b1424d5bd1fa1L12-R12)

These changes collectively improve the maintainability and readability of the codebase while introducing a mechanism to enforce consistent formatting.