### PR TITLE
LLM custom model security checks

### DIFF
--- a/crates/blockless-drivers/src/error.rs
+++ b/crates/blockless-drivers/src/error.rs
@@ -215,4 +215,5 @@ pub enum LlmErrorKind {
     Utf8Error,                 // 7
     RuntimeError,              // 8
     MCPFunctionCallError,      // 9
+    PermissionDeny,            // 10
 }

--- a/crates/blockless-drivers/src/llm_driver/models.rs
+++ b/crates/blockless-drivers/src/llm_driver/models.rs
@@ -232,9 +232,16 @@ impl FromStr for Models {
                 Ok(Models::Gemma29BInstruct(Some("q4f16_1".to_string())))
             }
             // Model must be a valid URL
-            _ => url::Url::parse(s)
-                .map(Models::Url)
-                .map_err(|_| format!("Invalid model url: {}", s)),
+            _ => {
+                let url =
+                    url::Url::parse(s).map_err(|_| format!("Invalid model name or URL: {}", s))?;
+
+                // Apply security validation to custom URLs
+                let security_config = SecurityConfig::default();
+                security_config.validate_model_url(&url)?;
+
+                Ok(Models::Url(url))
+            }
         }
     }
 }

--- a/crates/blockless-drivers/witx/blockless_llm.witx
+++ b/crates/blockless-drivers/witx/blockless_llm.witx
@@ -20,6 +20,8 @@
     $runtime_error
     ;;; MCP function call error
     $mcp_function_call_error
+    ;;; Permission denied
+    $permission_deny
   )
 )
 


### PR DESCRIPTION
## Description

This pull request introduces enhanced security measures for handling model URLs in the `blockless-drivers` crate, along with related updates to error handling and testing.
The key changes include the addition of a URL permission checker, a new `PermissionDeny` error kind, and a `SecurityConfig` struct for validating model URLs.
These changes improve the robustness and security of the LLM driver.

### Security Enhancements:
* Added `SecurityConfig` struct in `crates/blockless-drivers/src/llm_driver/models.rs` to validate model URLs based on HTTPS requirements, domain allowlists, file extensions, and other security checks. (`[crates/blockless-drivers/src/llm_driver/models.rsR3-R104](diffhunk://#diff-d47c73cb4cb3ffef9e17a5c245b67c6c1def39bbd2630f2fbc0ba5a2086643e0R3-R104)`)
* Updated `impl FromStr for Models` to apply `SecurityConfig` validation for custom model URLs. (`[crates/blockless-drivers/src/llm_driver/models.rsL133-R244](diffhunk://#diff-d47c73cb4cb3ffef9e17a5c245b67c6c1def39bbd2630f2fbc0ba5a2086643e0L133-R244)`)

### Error Handling:
* Introduced a new `PermissionDeny` variant to `LlmErrorKind` in `crates/blockless-drivers/src/error.rs` to represent permission denial errors. (`[crates/blockless-drivers/src/error.rsR218](diffhunk://#diff-135e4d46018a9ccbbefdc3a10ad58837ca465b36affb65d3c7a77878df40c9a0R218)`)
* Updated error conversion and handling logic in `crates/blockless-drivers/src/wasi/llm.rs` to include the `PermissionDeny` error. (`[[1]](diffhunk://#diff-252d4e6bf7d93b07f8f5628da28fc5da71a4ccb1f11cc2ec4d241e1bb09ab0e4R36)`, `[[2]](diffhunk://#diff-252d4e6bf7d93b07f8f5628da28fc5da71a4ccb1f11cc2ec4d241e1bb09ab0e4L63-R68)`)
* Added `$permission_deny` to the WITX file to reflect the new error kind. (`[crates/blockless-drivers/witx/blockless_llm.witxR23-R24](diffhunk://#diff-09e4b708b94d961c68c8af31f8303654ef53949f2a07f319b9727d5f227520b3R23-R24)`)

### URL Permission Checker:
* Modified `llm_set_model` in `crates/blockless-drivers/src/llm_driver/mod.rs` to accept a closure (`url_permission_checker`) for URL validation, and integrated it into the model setup process. (`[crates/blockless-drivers/src/llm_driver/mod.rsL68-R82](diffhunk://#diff-2332f6c18f1579ddb2f12c275b8a664bf3547342c66874f5adee8232a1ee35d9L68-R82)`)

### Testing:
* Added unit tests in `crates/blockless-drivers/src/llm_driver/models.rs` to validate `SecurityConfig` behavior and ensure proper handling of valid and invalid URLs. (`[crates/blockless-drivers/src/llm_driver/models.rsR263-R364](diffhunk://#diff-d47c73cb4cb3ffef9e17a5c245b67c6c1def39bbd2630f2fbc0ba5a2086643e0R263-R364)`)
* Enhanced integration tests in `crates/blockless-drivers/src/llm_driver/mod.rs` to use the URL permission checker and verify its functionality. (`[[1]](diffhunk://#diff-2332f6c18f1579ddb2f12c275b8a664bf3547342c66874f5adee8232a1ee35d9L279-R292)`, `[[2]](diffhunk://#diff-2332f6c18f1579ddb2f12c275b8a664bf3547342c66874f5adee8232a1ee35d9L345-R358)`, `[[3]](diffhunk://#diff-2332f6c18f1579ddb2f12c275b8a664bf3547342c66874f5adee8232a1ee35d9R387-R421)`)
