### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -16,20 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - run: rustup override set nightly
-      - run: cargo fmt --all -- --check
       - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - name: Run nightly fmt check
         run: cargo +nightly fmt --all -- --check
+      - name: Run check
+        run: cargo check --all-targets --all-features
       - name: Run clippy
-        run: |
-          rustup override set 1.85
-          rustup component add --toolchain 1.85-x86_64-unknown-linux-gnu clippy
-          cargo clippy --all-features --all-targets -- -D warnings
-          cargo check --release --all --all-features
-          cargo test --all --all-features
+        run: cargo clippy --all-features --all-targets -- -D warnings
+      - name: Run tests
+        run: cargo test --all --all-features

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -16,11 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
+
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - name: Run nightly fmt check
         run: cargo +nightly fmt --all -- --check
+
+      - uses: dtolnay/rust-toolchain@1.85
+        with:
+          components: rustfmt
       - name: Run check
         run: cargo check --all-targets --all-features
       - name: Run clippy

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -12,17 +12,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  fmt-clippy-check-test:
+  nightly-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - name: Run nightly fmt check
         run: cargo +nightly fmt --all -- --check
 
+  stable-clippy-check-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt

--- a/crates/blockless-drivers/src/llm_driver/mcp.rs
+++ b/crates/blockless-drivers/src/llm_driver/mcp.rs
@@ -346,13 +346,14 @@ mod tests {
     static INIT: Once = Once::new();
     fn init_tracing() {
         INIT.call_once(|| {
-            tracing_subscriber::registry()
+            // Try to initialize the global subscriber, but ignore errors if it's already set
+            let _ = tracing_subscriber::registry()
                 .with(
                     tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| "debug".into()),
                 )
                 .with(tracing_subscriber::fmt::layer())
-                .init();
+                .try_init();
         });
     }
 


### PR DESCRIPTION
This pull request includes updates to the CI workflow and error handling in tracing initialization.
The most important changes are improvements to the `.github/workflows/rust-fmt.yml` file for better CI coverage and a modification to the `init_tracing` function in `mcp.rs` to handle potential errors gracefully.

### CI Workflow Updates:
* [`.github/workflows/rust-fmt.yml`](diffhunk://#diff-8c3161f8cbf684f0a4c2b7f8ac5dc4e4b5c8ffd20d4060537fa73d357340df7aL19-R29): Updated the Rust toolchain to version `1.85` for consistency, added a `cargo check` step to verify all targets and features, and streamlined the `clippy` and `test` steps by removing redundant commands.

### Error Handling Improvements:
* [`crates/blockless-drivers/src/llm_driver/mcp.rs`](diffhunk://#diff-12211de0af355bc77db494b549e849f45669dca86ad2fb0d9a4fbf6ba187c02aL349-R356): Modified the `init_tracing` function to use `try_init` instead of `init`, allowing the global subscriber initialization to gracefully handle errors if it is already set.