### PR TITLE
fix the test issue for cicd

### DIFF
--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
       - name: Run tests
-        run: cargo test --all --all-features
+        run: cargo test --all --all-features -- --test-threads=1

--- a/.github/workflows/rust-grcov.yml
+++ b/.github/workflows/rust-grcov.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all -- --test-threads=1
         env:
           CARGO_INCREMENTAL: 0
           LLVM_PROFILE_FILE: "run-%m.profraw"


### PR DESCRIPTION
## Description
This pull request updates the test configurations in GitHub Actions workflows to ensure tests run in a single thread. 
This change is likely aimed at addressing issues related to concurrency or improving test reliability.

### Workflow Updates for Test Execution:

* [`.github/workflows/rust-fmt.yml`](diffhunk://#diff-8c3161f8cbf684f0a4c2b7f8ac5dc4e4b5c8ffd20d4060537fa73d357340df7aL37-R37): Modified the `cargo test` command to include the `--test-threads=1` flag, ensuring tests run with a single thread.
* [`.github/workflows/rust-grcov.yml`](diffhunk://#diff-cbfd7cb50ee220295bb8acdd1f3bf5df6cb9c4863d1e0883077c4eb209ee0f87L28-R28): Updated the `args` for the `cargo test` command to include the `--test-threads=1` flag, aligning the test execution strategy across workflows.