### PR TITLE
removed ci steps from running on main after merge

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -10,13 +10,9 @@
 name: rust-clippy analyze
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '44 8 * * 4'
+    branches:
+      - main
 
 jobs:
   rust-clippy-analyze:
@@ -44,9 +40,3 @@ jobs:
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
-
-      - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: rust-clippy-results.sarif
-          wait-for-processing: true

--- a/.github/workflows/rust-grcov.yml
+++ b/.github/workflows/rust-grcov.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+
+on:
+  pull_request:
+    branches:
+      - main
 
 name: Code coverage with grcov
 


### PR DESCRIPTION
## Description

This pull request updates GitHub Actions workflows related to Rust linting and code coverage.
The changes simplify the workflows by removing unused triggers and steps, focusing on pull request events targeting the `main` branch.

### Changes to `.github/workflows/rust-clippy.yml`:

* Removed the `push` and `schedule` triggers, leaving only the `pull_request` trigger for the `main` branch.
* Deleted the step that uploads analysis results to GitHub, streamlining the workflow.

### Changes to `.github/workflows/rust-grcov.yml`:

* Replaced the combined `push` and `pull_request` triggers with a specific `pull_request` trigger targeting the `main` branch.